### PR TITLE
Criar servidor TCP

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -2,13 +2,14 @@ require 'socket'
 
 server = TCPServer.new(5000)
 
+TIMEOUT = 10
+MAX_REQUESTS = 100
+
 # Aceitando conexões enquanto o loop estiver sendo executado
 loop do
     # Aceita conexões simultâneas
     Thread.new(server.accept) do |socket|
         begin
-            TIMEOUT = 10
-            MAX_REQUESTS = 100
             request_count = 0
             loop do
                 # Espera a leitura do socket por TIMEOUT segundos

--- a/main.rb
+++ b/main.rb
@@ -1,32 +1,4 @@
-require 'socket'
+require_relative 'server'
 
-server = TCPServer.new(5000)
-
-TIMEOUT = 10
-MAX_REQUESTS = 100
-
-# Aceitando conexões enquanto o loop estiver sendo executado
-loop do
-    # Aceita conexões simultâneas
-    Thread.new(server.accept) do |socket|
-        begin
-            request_count = 0
-            loop do
-                # Espera a leitura do socket por TIMEOUT segundos
-                ready = IO.select([socket], nil, nil, TIMEOUT)
-                break unless ready
-                # Responde mensagem do cliente no socket
-                line = socket.gets
-                puts "O cliente disse: #{line}"
-                socket.puts "Você disse: #{line}"
-                # Conta as requisições
-                request_count += 1
-                break if request_count >= MAX_REQUESTS
-            end
-        rescue => e
-            puts "Erro: #{e}"
-        ensure
-            socket.close
-        end
-    end
-end
+server = Server.new(5000)
+server.start

--- a/main.rb
+++ b/main.rb
@@ -7,11 +7,17 @@ loop do
     # Aceita conexões simultâneas
     Thread.new(server.accept) do |socket|
         begin
-            # Responde mensagens do cliente no socket
-            while line = socket.gets
+            TIMEOUT = 10
+            loop do
+                # Espera a leitura do socket por TIMEOUT segundos
+                ready = IO.select([socket], nil, nil, TIMEOUT)
+                break unless ready
+                # Responde mensagem do cliente no socket
+                line = socket.gets
                 puts "O cliente disse: #{line}"
                 socket.puts "Você disse: #{line}"
             end
+            socket.close
         rescue => e
             puts "Erro: #{e}"
         end

--- a/main.rb
+++ b/main.rb
@@ -1,0 +1,15 @@
+require 'socket'
+
+server = TCPServer.new(5000)
+
+# Aceitando conexões enquanto o loop estiver sendo executado
+loop do
+    # Aceita conexões simultâneas
+    Thread.new(server.accept) do |socket|
+        # Responde mensagens do cliente no socket
+        while line = socket.gets
+            puts "O cliente disse: #{line}"
+            socket.puts "Você disse: #{line}"
+        end
+    end
+end

--- a/main.rb
+++ b/main.rb
@@ -22,9 +22,10 @@ loop do
                 request_count += 1
                 break if request_count >= MAX_REQUESTS
             end
-            socket.close
         rescue => e
             puts "Erro: #{e}"
+        ensure
+            socket.close
         end
     end
 end

--- a/main.rb
+++ b/main.rb
@@ -6,10 +6,14 @@ server = TCPServer.new(5000)
 loop do
     # Aceita conexões simultâneas
     Thread.new(server.accept) do |socket|
-        # Responde mensagens do cliente no socket
-        while line = socket.gets
-            puts "O cliente disse: #{line}"
-            socket.puts "Você disse: #{line}"
+        begin
+            # Responde mensagens do cliente no socket
+            while line = socket.gets
+                puts "O cliente disse: #{line}"
+                socket.puts "Você disse: #{line}"
+            end
+        rescue => e
+            puts "Erro: #{e}"
         end
     end
 end

--- a/main.rb
+++ b/main.rb
@@ -8,6 +8,8 @@ loop do
     Thread.new(server.accept) do |socket|
         begin
             TIMEOUT = 10
+            MAX_REQUESTS = 100
+            request_count = 0
             loop do
                 # Espera a leitura do socket por TIMEOUT segundos
                 ready = IO.select([socket], nil, nil, TIMEOUT)
@@ -16,6 +18,9 @@ loop do
                 line = socket.gets
                 puts "O cliente disse: #{line}"
                 socket.puts "Você disse: #{line}"
+                # Conta as requisições
+                request_count += 1
+                break if request_count >= MAX_REQUESTS
             end
             socket.close
         rescue => e

--- a/server.rb
+++ b/server.rb
@@ -1,0 +1,37 @@
+require 'socket'
+
+class Server
+    def initialize(port)
+        @timeout = 10
+        @max_requests = 100
+        @server = TCPServer.new(port)
+    end
+
+    def start
+        # Aceitando conexões enquanto o loop estiver sendo executado
+        loop do
+            # Aceita conexões simultâneas
+            Thread.new(@server.accept) do |socket|
+                begin
+                    request_count = 0
+                    loop do
+                        # Espera a leitura do socket por TIMEOUT segundos
+                        ready = IO.select([socket], nil, nil, @timeout)
+                        break unless ready
+                        # Responde mensagem do cliente no socket
+                        line = socket.gets
+                        puts "O cliente disse: #{line}"
+                        socket.puts "Você disse: #{line}"
+                        # Conta as requisições
+                        request_count += 1
+                        break if request_count >= @max_requests
+                    end
+                rescue => e
+                    puts "Erro: #{e}"
+                ensure
+                    socket.close
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
# Contexto

Um __Servidor Web__ é responsável pelo armazenamento, processamento e entrega dos arquivos dos sites para os navegadores. Para isso o Servidor se comunica com o Navegador através de um protocolo de comunicação chamado __Protocolo de Transporte de Hipertexto__ ou simplesmente __HTTP__.  
Salvo raras exceções, o protocolo __HTTP__ é encapsulado dentro de outro protocolo que é o __Protocolo de Controle de Transmissão__ ou __TCP__.

# Descrição

Para criar o __Servidor Web__ então, é necessário criar um servidor que envie e receba dados através do protocolo __HTTP__, para que assim ele se comunique com o Navegador.  
Porém, como o __HTTP__ é um protocolo que esta encapsulado dentro do Protocolo __TCP__, foi necessário construir primeiro um __Servidor TCP__, para que no futuro atualizações sejam feitas para a utilização do __HTTP__ e a comunicação com os Navegadores.

# Código

Para a criação do __Servidor TCP__ foi utilizado uma Biblioteca nativa do Ruby chamada ```socket```. Foi criado então a classe ```Server``` que recebe como parâmetro para a sua criação a porta utilizada para conexão __TCP__. A classe conta com a função ```start``` que inicia o servidor TCP no endereço localhost e na porta passada na criação do servidor. O Servidor tem um limite de __100__ mensagens por conexão e tolera um tempo de inatividade de __5__ segundos antes de desconectar o cliente. Além disso utiliza a classe ```Thread``` para aceitar conexões simultaneas.  
A criação do servidor é feita através da criação de um objeto da classe ```TCPServer``` da bibliota, e a comunicação com o cliente é feita através das funções ```gets``` e ```puts``` do objeto da classe ```TCPSocket``` que é retornado pelo objeto do servidor quando o cliente se conecta.